### PR TITLE
fix bug for issue #1

### DIFF
--- a/src/ug_cmaplap/cmapLapParaSolver.cpp
+++ b/src/ug_cmaplap/cmapLapParaSolver.cpp
@@ -1034,6 +1034,8 @@ CMapLapParaSolver::processTagCMapLapPackedVector(
       case Sieve:
          nVectorsReceivedSieve += receivedPackedVector->getNVectors();
          break;
+      case Undefined:
+         break;
       default:
          THROW_LOGICAL_ERROR2("CMapLapParaSolver::processTagCMapLapPackedVector: Invalid solver type = ",static_cast<int>(getSolverType()));
    }
@@ -2153,6 +2155,8 @@ CMapLapParaSolver::sendSolution(
             break;
          case Sieve:
             nVectorsSentSieve++;
+            break;
+         case Undefined:
             break;
          default:
             THROW_LOGICAL_ERROR2("CMapLapParaSolver::sendSolution: Invalid solver type = ",static_cast<int>(getSolverType()));

--- a/src/ug_cmaplap/cmapLapParaSolver.h
+++ b/src/ug_cmaplap/cmapLapParaSolver.h
@@ -576,8 +576,14 @@ public:
    virtual SolverType getSolverType(
          )
    {
-      assert( currentTask );
-      return (dynamic_cast<CMapLapParaTask *>(currentTask))->getSolverType();
+      if( currentTask )
+      {
+         return (dynamic_cast<CMapLapParaTask *>(currentTask))->getSolverType();
+      }
+      else
+      {
+         return Undefined;
+      }
    }
 
    virtual void writeCurrentTaskProblem(const std::string& filename){ throw "** writeCurrentNodeProblem is called **"; };


### PR DESCRIPTION
## Description

This segmentation fault (#1) occurs when the solver receives a base or vector of lattices between the time it finishes a task and receives a new task.
I changed CMapLapParaSolver::getSolverType return Undefined if the solver does not have currentTask.

## Test

- python3 test.py -i ./storage/sample_mats/dim10.txt -np 35 → all tests are passed.